### PR TITLE
Updated AL-Go System Files

### DIFF
--- a/.AL-Go/cloudDevEnv.ps1
+++ b/.AL-Go/cloudDevEnv.ps1
@@ -6,7 +6,8 @@
 Param(
     [string] $environmentName = "",
     [bool] $reuseExistingEnvironment,
-    [switch] $fromVSCode
+    [switch] $fromVSCode,
+    [switch] $clean
 )
 
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
@@ -27,11 +28,11 @@ Write-Host -ForegroundColor Yellow @'
 $webClient = New-Object System.Net.WebClient
 $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
 $webClient.Encoding = [System.Text.Encoding]::UTF8
-$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/Github-Helper.psm1'
+$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.1/Github-Helper.psm1'
 Write-Host "Downloading GitHub Helper module from $GitHubHelperUrl"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
 $webClient.DownloadFile($GitHubHelperUrl, $GitHubHelperPath)
-$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/AL-Go-Helper.ps1'
+$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.1/AL-Go-Helper.ps1'
 Write-Host "Downloading AL-Go Helper script from $ALGoHelperUrl"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient.DownloadFile($ALGoHelperUrl, $ALGoHelperPath)
@@ -78,7 +79,8 @@ CreateDevEnv `
     -environmentName $environmentName `
     -reuseExistingEnvironment:$reuseExistingEnvironment `
     -baseFolder $baseFolder `
-    -project $project
+    -project $project `
+    -clean:$clean
 }
 catch {
     Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"

--- a/.AL-Go/localDevEnv.ps1
+++ b/.AL-Go/localDevEnv.ps1
@@ -5,11 +5,13 @@
 #
 Param(
     [string] $containerName = "",
+    [ValidateSet("UserPassword", "Windows")]
     [string] $auth = "",
     [pscredential] $credential = $null,
     [string] $licenseFileUrl = "",
     [switch] $fromVSCode,
-    [switch] $accept_insiderEula
+    [switch] $accept_insiderEula,
+    [switch] $clean
 )
 
 $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
@@ -30,11 +32,11 @@ Write-Host -ForegroundColor Yellow @'
 $webClient = New-Object System.Net.WebClient
 $webClient.CachePolicy = New-Object System.Net.Cache.RequestCachePolicy -argumentList ([System.Net.Cache.RequestCacheLevel]::NoCacheNoStore)
 $webClient.Encoding = [System.Text.Encoding]::UTF8
-$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/Github-Helper.psm1'
+$GitHubHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.1/Github-Helper.psm1'
 Write-Host "Downloading GitHub Helper module from $GitHubHelperUrl"
 $GitHubHelperPath = "$([System.IO.Path]::GetTempFileName()).psm1"
 $webClient.DownloadFile($GitHubHelperUrl, $GitHubHelperPath)
-$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/AL-Go-Helper.ps1'
+$ALGoHelperUrl = 'https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.1/AL-Go-Helper.ps1'
 Write-Host "Downloading AL-Go Helper script from $ALGoHelperUrl"
 $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
 $webClient.DownloadFile($ALGoHelperUrl, $ALGoHelperPath)
@@ -134,7 +136,8 @@ CreateDevEnv `
     -auth $auth `
     -credential $credential `
     -licenseFileUrl $licenseFileUrl `
-    -accept_insiderEula:$accept_insiderEula
+    -accept_insiderEula:$accept_insiderEula `
+    -clean:$clean
 }
 catch {
     Write-Host -ForegroundColor Red "Error: $($_.Exception.Message)`nStacktrace: $($_.scriptStackTrace)"

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -1,3 +1,107 @@
+## v5.1
+
+### Issues
+
+- Issue 1019 CI/CD Workflow still being scheduled after it was disabled
+- Issue 1021 Error during Create Online Development Environment action
+- Issue 1022 Error querying artifacts: No such host is known. (bcartifacts-exdbf9fwegejdqak.blob.core.windows.net:443)
+- Issue 922 Deploy Reference Documentation (ALDoc) failed with custom
+- ContainerName used during build was invalid if project names contained special characters
+- Issue 1009 by adding a includeDependencies property in DeliverToAppSource
+- Issue 997 'Deliver to AppSource' action fails for projects containing a space
+- Issue 987 Resource not accessible by integration when creating release from specific version
+- Issue 979 Publish to AppSource Documentation
+- Issue 1018 Artifact setting - possibility to read version from app.json
+- Issue 1008 Allow PullRequestHandler to use ubuntu or self hosted runners for all jobs except for pregateCheck
+- Issue 962 Finer control of "shell"-property
+- Issue 1041 Harden the version comparison when incrementing version number
+- Issue 1042 Downloading artifacts from GitHub doesn't work with branch names which include forward slashes
+
+### Better artifact selection
+
+The artifact setting in your project settings file can now contain a `*` instead of the version number. This means that AL-Go for GitHub will determine the application dependency for your projects together with the `applicationDependency` setting and determine which Business Central version is needed for the project.
+- `"artifact": "//*//latest"` will give you the latest Business Central version, higher than your application dependency and with the same major.minor as your application dependency.
+- `"artifact": "//*//first"` will give you the first Business Central version, higher than your application dependency and with the same major.minor as your application dependency.
+
+### New Settings
+
+- `deliverToAppSource`: a JSON object containing the following properties
+  - **productId** must be the product Id from partner Center.
+  - **mainAppFolder** specifies the appFolder of the main app if you have multiple apps in the same project.
+  - **continuousDelivery** can be set to true to enable continuous delivery of every successful build to AppSource Validation. Note that the app will only be in preview in AppSource and you will need to manually press GO LIVE in order for the app to be promoted to production.
+  - **includeDependencies** can be set to an array of file names (incl. wildcards) which are the names of the dependencies to include in the AppSource submission. Note that you need to set `generateDependencyArtifact` in the project settings file to true in order to include dependencies.
+- Add `shell` as a property under `DeployTo` structure
+
+### Deprecated Settings
+
+- `appSourceContinuousDelivery` is moved to the `deliverToAppSource` structure
+- `appSourceMainAppFolder` is moved to the `deliverToAppSource` structure
+- `appSourceProductId` is moved to the `deliverToAppSource` structure
+
+### New parameter -clean on localdevenv and clouddevenv
+
+Adding -clean when running localdevenv or clouddevenv will create a clean development environment without compiling and publishing your apps.
+
+## v5.0
+
+### Issues
+- Issue 940 Publish to Environment is broken when specifying projects to publish
+- Issue 994 CI/CD ignores Deploy to GitHub Pages in private repositories
+
+### New Settings
+- `UpdateALGoSystemFilesEnvironment`: The name of the environment that is referenced in job `UpdateALGoSystemFiles` in the _Update AL-Go System Files_ workflow. See [jobs.<job_id>.environment](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) for more information. Currently, only setting the environment name is supported.
+
+### Issues
+- Support release branches that start with releases/
+- Issue 870 Improve Error Handling when CLI is missing
+- Issue 889 CreateRelease and IncrementVersionNumber workflow did not handle wild characters in `appFolders`, `testFolders` or `bcptTestFolders` settings.
+- Issue 973 Prerelease is not used for deployment
+
+### Build modes
+AL-Go ships with Default, Translated and Clean mode out of the box. Now you can also define custom build modes in addition to the ones shipped with AL-Go. This allows you to define your own build modes, which can be used to build your apps in different ways. By default, a custom build mode will build the apps similarly to the Default mode but this behavior can be overridden in e.g. script overrides in your repository.
+
+## v4.1
+
+### New Settings
+- `templateSha`: The SHA of the version of AL-Go currently used
+
+### New Actions
+- `DumpWorkflowInfo`: Dump information about running workflow
+- `Troubleshooting` : Run troubleshooting for repository
+
+### Update AL-Go System Files
+Add another parameter when running Update AL-Go System Files, called downloadLatest, used to indicate whether to download latest version from template repository. Default value is true.
+If false, the templateSha repository setting is used to download specific AL-Go System Files when calculating new files.
+
+### Issues
+- Issue 782 Exclude '.altestrunner/' from template .gitignore
+- Issue 823 Dependencies from prior build jobs are not included when using useProjectDependencies
+- App artifacts for version 'latest' are now fetched from the latest CICD run that completed and successfully built all the projects for the corresponding branch.
+- Issue 824 Utilize `useCompilerFolder` setting when creating an development environment for an AL-Go project.
+- Issue 828 and 825 display warnings for secrets, which might cause AL-Go for GitHub to malfunction
+
+### New Settings
+
+- `alDoc` : JSON object with properties for the ALDoc reference document generation
+  - **continuousDeployment** = Determines if reference documentation will be deployed continuously as part of CI/CD. You can run the **Deploy Reference Documentation** workflow to deploy manually or on a schedule. (Default false)
+  - **deployToGitHubPages** = Determines whether or not the reference documentation site should be deployed to GitHub Pages for the repository. In order to deploy to GitHub Pages, GitHub Pages must be enabled and set to GitHub Actions. (Default true)
+  - **maxReleases** = Maximum number of releases to include in the reference documentation. (Default 3)
+  - **groupByProject** = Determines whether projects in multi-project repositories are used as folders in reference documentation
+  - **includeProjects** = An array of projects to include in the reference documentation. (Default all)
+  - **excludeProjects** = An array of projects to exclude in the reference documentation. (Default none)-
+  - **header** = Header for the documentation site. (Default: Documentation for...)
+  - **footer** = Footer for the documentation site. (Default: Made with...)
+  - **defaultIndexMD** = Markdown for the landing page of the documentation site. (Default: Reference documentation...)
+  - **defaultReleaseMD** = Markdown for the landing page of the release sites. (Default: Release reference documentation...)
+  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}*
+
+### New Workflows
+- **Deploy Reference Documentation** is a workflow, which you can invoke manually or on a schedule to generate and deploy reference documentation using the aldoc tool, using the ALDoc setting properties described above.
+- **Troubleshooting** is a workflow, which you can invoke manually to run troubleshooting on the repository and check for settings or secrets, containing illegal values. When creating issues on https://github.com/microsoft/AL-Go/issues, we might ask you to run the troubleshooter to help identify common problems.
+
+### Support for ALDoc reference documentation tool
+ALDoc reference documentation tool is now supported for generating and deploying reference documentation for your projects either continuously or manually/scheduled.
+
 ## v4.0
 
 ### Removal of the InsiderSasToken

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -13,12 +13,13 @@ on:
         description: Direct Download Url of .app or .zip file
         required: true
       directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Direct Commit?
         type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -34,26 +35,32 @@ env:
 
 jobs:
   AddExistingAppOrTestApp:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0090"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -61,7 +68,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Add existing app
-        uses: microsoft/AL-Go-Actions/AddExistingApp@v4.0
+        uses: microsoft/AL-Go-Actions/AddExistingApp@v5.1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -72,7 +79,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0090"

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -16,6 +16,7 @@ defaults:
 permissions:
   contents: read
   actions: read
+  pages: read
 
 env:
   workflowDepth: 1
@@ -24,12 +25,15 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       environmentsMatrixJson: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentsMatrixJson }}
       environmentCount: ${{ steps.DetermineDeploymentEnvironments.outputs.EnvironmentCount }}
       deploymentEnvironmentsJson: ${{ steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
+      generateALDocArtifact: ${{ steps.DetermineDeploymentEnvironments.outputs.GenerateALDocArtifact }}
+      deployALDocArtifact: ${{ steps.DetermineDeploymentEnvironments.outputs.DeployALDocArtifact }}
       deliveryTargetsJson: ${{ steps.DetermineDeliveryTargets.outputs.DeliveryTargetsJson }}
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
       githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
@@ -38,21 +42,26 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0091"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
           get: type
@@ -64,22 +73,22 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v5.1
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
-          checkContextSecrets: 'N'
+          checkContextSecrets: 'false'
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -87,17 +96,17 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineDeliveryTargets@v5.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
-          checkContextSecrets: 'Y'
+          checkContextSecrets: 'true'
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v5.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -106,24 +115,24 @@ jobs:
           type: 'CD'
 
   CheckForUpdates:
-    runs-on: [ windows-latest ]
     needs: [ Initialization ]
+    runs-on: [ windows-latest ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
           get: templateUrl
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v4.0
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v5.1
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
           templateUrl: ${{ env.templateUrl }}
+          downloadLatest: true
 
   Build:
     needs: [ Initialization ]
@@ -145,9 +154,56 @@ jobs:
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
       secrets: 'licenseFileUrl,codeSignCertificateUrl,*codeSignCertificatePassword,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
       publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
-      publishArtifacts: ${{ github.ref_name == 'main' || startswith(github.ref_name, 'release/') || needs.Initialization.outputs.deliveryTargetsJson != '[]' || needs.Initialization.outputs.environmentCount > 0 }}
+      publishArtifacts: ${{ github.ref_name == 'main' || startswith(github.ref_name, 'release/') || startswith(github.ref_name, 'releases/') || needs.Initialization.outputs.deliveryTargetsJson != '[]' || needs.Initialization.outputs.environmentCount > 0 }}
       signArtifacts: true
       useArtifactCache: true
+
+  DeployALDoc:
+    needs: [ Initialization, Build ]
+    if: always() && needs.Build.result == 'Success' && needs.Initialization.outputs.generateALDocArtifact == 1 && github.ref_name == 'main'
+    runs-on: windows-latest
+    name: Deploy Reference Documentation
+    permissions:
+      contents: read
+      actions: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: '.artifacts'
+
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
+        with:
+          shell: powershell
+
+      - name: Setup Pages
+        if: needs.Initialization.outputs.deployALDocArtifact == 1
+        uses: actions/configure-pages@v5
+
+      - name: Build Reference Documentation
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v5.1
+        with:
+          shell: powershell
+          artifacts: '.artifacts'
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ".aldoc/_site/"
+
+      - name: Deploy to GitHub Pages
+        if: needs.Initialization.outputs.deployALDocArtifact == 1
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   Deploy:
     needs: [ Initialization, Build ]
@@ -155,22 +211,25 @@ jobs:
     strategy: ${{ fromJson(needs.Initialization.outputs.environmentsMatrixJson) }}
     runs-on: ${{ fromJson(matrix.os) }}
     name: Deploy to ${{ matrix.environment }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.Deploy.outputs.environmentUrl }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
 
       - name: EnvName
         id: envName
@@ -181,19 +240,19 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
       - name: Deploy
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v4.0
+        uses: microsoft/AL-Go-Actions/Deploy@v5.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           environmentName: ${{ matrix.environment }}
           artifacts: '.artifacts'
           type: 'CD'
@@ -210,28 +269,28 @@ jobs:
     name: Deliver to ${{ matrix.deliveryTarget }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go-Actions/Deliver@v4.0
+        uses: microsoft/AL-Go-Actions/Deliver@v5.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -242,16 +301,16 @@ jobs:
           artifacts: '.artifacts'
 
   PostProcess:
+    needs: [ Initialization, Build, Deploy, Deliver, DeployALDoc ]
     if: (!cancelled())
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Build, Deploy, Deliver ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0091"

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -19,16 +19,17 @@ on:
         description: ID range (from..to)
         required: true
       sampleCode:
-        description: Include Sample code (Y/N)
-        required: false
-        default: 'Y'
-      directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: "N"
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Include Sample code?
         type: boolean
+        default: true
+      directCommit:
+        description: Direct Commit?
+        type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -44,27 +45,33 @@ env:
 
 jobs:
   CreateApp:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0092"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
           get: type
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -72,7 +79,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new app
-        uses: microsoft/AL-Go-Actions/CreateApp@v4.0
+        uses: microsoft/AL-Go-Actions/CreateApp@v5.1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -87,7 +94,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0092"

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -13,16 +13,17 @@ on:
         description: Name of the online environment
         required: true
       reUseExistingEnvironment:
-        description: Reuse environment if it exists
-        required: false
-        default: 'N'
-      directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Reuse environment if it exists?
         type: boolean
+        default: false
+      directCommit:
+        description: Direct Commit?
+        type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -38,6 +39,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       deviceCode: ${{ steps.authenticate.outputs.deviceCode }}
@@ -45,25 +47,30 @@ jobs:
       githubRunner: ${{ steps.ReadSettings.outputs.GitHubRunnerJson }}
       githubRunnerShell: ${{ steps.ReadSettings.outputs.GitHubRunnerShell }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0093"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -82,7 +89,7 @@ jobs:
             Write-Host "AdminCenterApiCredentials not provided, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.1/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -91,26 +98,26 @@ jobs:
           }
 
   CreateDevelopmentEnvironment:
+    needs: [ Initialization ]
     runs-on: ${{ fromJson(needs.Initialization.outputs.githubRunner) }}
     defaults:
       run:
         shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
     name: Create Development Environment
-    needs: [ Initialization ]
     env:
       deviceCode: ${{ needs.Initialization.outputs.deviceCode }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -129,7 +136,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -value "adminCenterApiCredentials=$adminCenterApiCredentials"
 
       - name: Create Development Environment
-        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v4.0
+        uses: microsoft/AL-Go-Actions/CreateDevelopmentEnvironment@v5.1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -142,7 +149,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0093"

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -21,20 +21,21 @@ on:
         required: true
         default: '50000..99999'
       sampleCode:
-        description: Include Sample code (Y/N)
-        required: false
-        default: 'Y'
-      sampleSuite:
-        description: Include Sample BCPT Suite (Y/N)
-        required: false
-        default: 'Y'
-      directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Include Sample code?
         type: boolean
+        default: true
+      sampleSuite:
+        description: Include Sample BCPT Suite?
+        type: boolean
+        default: true
+      directCommit:
+        description: Direct Commit?
+        type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -50,26 +51,32 @@ env:
 
 jobs:
   CreatePerformanceTestApp:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0102"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -77,7 +84,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v4.0
+        uses: microsoft/AL-Go-Actions/CreateApp@v5.1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -93,7 +100,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0102"

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -1,4 +1,5 @@
 name: ' Create release'
+run-name: "Create release - Version ${{ inputs.tag }}"
 
 on:
   workflow_dispatch:
@@ -16,28 +17,33 @@ on:
         required: true
         default: ''
       prerelease:
-        description: Prerelease (Y/N)
-        required: false
-        default: 'N'
+        description: Prerelease?
+        type: boolean
+        default: false
       draft:
-        description: Draft (Y/N)
-        required: false
-        default: 'N'
+        description: Draft?
+        type: boolean
+        default: false
       createReleaseBranch:
-        description: Create Release Branch (Y/N)
-        required: false
-        default: 'N'
+        description: Create Release Branch?
+        type: boolean
+        default: false
+      releaseBranchPrefix:
+        description: The prefix for the release branch. Used only if 'Create Release Branch?' is checked.
+        type: string
+        default: release/
       updateVersionNumber:
         description: New Version Number in main branch. Use Major.Minor for absolute change, use +Major.Minor for incremental change.
         required: false
         default: ''
       directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Direct Commit?
         type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -56,43 +62,58 @@ env:
 
 jobs:
   CreateRelease:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       artifacts: ${{ steps.analyzeartifacts.outputs.artifacts }}
       releaseId: ${{ steps.createrelease.outputs.releaseId }}
       commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
-      releaseBranch: ${{ steps.createreleasenotes.outputs.releaseBranch }}
+      releaseVersion: ${{ steps.createreleasenotes.outputs.releaseVersion }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0094"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
           get: templateUrl,repoName
 
+      - name: Read secrets
+        id: ReadSecrets
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
+        with:
+          shell: powershell
+          gitHubSecrets: ${{ toJson(secrets) }}
+          getSecrets: 'TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
+  
       - name: Determine Projects
         id: determineProjects
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.1
         with:
           shell: powershell
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v4.0
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v5.1
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           templateUrl: ${{ env.templateUrl }}
+          downloadLatest: true
 
       - name: Analyze Artifacts
         id: analyzeartifacts
@@ -108,10 +129,10 @@ jobs:
           $headers = @{
             "Authorization" = "token ${{ github.token }}"
             "X-GitHub-Api-Version" = "2022-11-28"
-            "Accept" = "application/vnd.github+json"
+            "Accept" = "application/vnd.github+json; charset=utf-8"
           }
           do {
-            $repoArtifacts = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/actions/artifacts?per_page=100&page=$page" | ConvertFrom-Json
+            $repoArtifacts = Invoke-RestMethod -UseBasicParsing -Headers $headers -Uri "$($ENV:GITHUB_API_URL)/repos/$($ENV:GITHUB_REPOSITORY)/actions/artifacts?per_page=100&page=$page"
             $allArtifacts += $repoArtifacts.Artifacts | Where-Object { !$_.expired }
             $page++
           }
@@ -173,7 +194,7 @@ jobs:
 
       - name: Prepare release notes
         id: createreleasenotes
-        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v4.0
+        uses: microsoft/AL-Go-Actions/CreateReleaseNotes@v5.1
         with:
           shell: powershell
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -181,12 +202,12 @@ jobs:
           target_commitish: ${{ steps.analyzeartifacts.outputs.commitish }}
 
       - name: Create release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: createrelease
         env:
           bodyMD: ${{ steps.createreleasenotes.outputs.releaseNotes }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           script: |
             var bodyMD = process.env.bodyMD
             const createReleaseResponse = await github.rest.repos.createRelease({
@@ -195,8 +216,8 @@ jobs:
               tag_name: '${{ github.event.inputs.tag }}',
               name: '${{ github.event.inputs.name }}',
               body: bodyMD.replaceAll('\\n','\n').replaceAll('%0A','\n').replaceAll('%0D','\n').replaceAll('%25','%'),
-              draft: ${{ github.event.inputs.draft=='Y' }},
-              prerelease: ${{ github.event.inputs.prerelease=='Y' }},
+              draft: ${{ github.event.inputs.draft=='true' }},
+              prerelease: ${{ github.event.inputs.prerelease=='true' }},
               make_latest: 'legacy',
               target_commitish: '${{ steps.analyzeartifacts.outputs.commitish }}'
             });
@@ -206,27 +227,28 @@ jobs:
             core.setOutput('releaseId', releaseId);
 
   UploadArtifacts:
-    runs-on: [ windows-latest ]
     needs: [ CreateRelease ]
+    runs-on: [ windows-latest ]
     strategy:
       matrix: ${{ fromJson(needs.CreateRelease.outputs.artifacts) }}
       fail-fast: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
-          getSecrets: 'nuGetContext,storageContext'
+          getSecrets: 'nuGetContext,storageContext,TokenForPush'
+          useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Download artifact
         run: |
@@ -240,15 +262,15 @@ jobs:
           Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri '${{ matrix.url }}' -OutFile '${{ matrix.name }}.zip'
 
       - name: Upload release artifacts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           releaseId: ${{ needs.createrelease.outputs.releaseId }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           script: |
             const releaseId = process.env.releaseId
             const assetPath = '${{ matrix.name }}.zip'
-            const assetName = '${{ matrix.name }}.zip'
+            const assetName = encodeURIComponent('${{ matrix.name }}.zip'.replaceAll(' ','.')).replaceAll('%','')
             const fs = require('fs');
             const uploadAssetResponse = await github.rest.repos.uploadReleaseAsset({
               owner: context.repo.owner,
@@ -259,7 +281,7 @@ jobs:
             });
 
       - name: Deliver to NuGet
-        uses: microsoft/AL-Go-Actions/Deliver@v4.0
+        uses: microsoft/AL-Go-Actions/Deliver@v5.1
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).nuGetContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -272,7 +294,7 @@ jobs:
           atypes: 'Apps,TestApps'
 
       - name: Deliver to Storage
-        uses: microsoft/AL-Go-Actions/Deliver@v4.0
+        uses: microsoft/AL-Go-Actions/Deliver@v5.1
         if: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).storageContext != '' }}
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -285,37 +307,44 @@ jobs:
           atypes: 'Apps,TestApps,Dependencies'
 
   CreateReleaseBranch:
-    if: ${{ github.event.inputs.createReleaseBranch=='Y' }}
-    runs-on: [ windows-latest ]
     needs: [ CreateRelease, UploadArtifacts ]
+    if: ${{ github.event.inputs.createReleaseBranch=='true' }}
+    runs-on: [ windows-latest ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: '${{ needs.createRelease.outputs.commitish }}'
 
       - name: Create Release Branch
+        env:
+          releaseBranchPrefix: ${{ github.event.inputs.releaseBranchPrefix }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
-          git checkout -b ${{ needs.CreateRelease.outputs.releaseBranch }}
+          $releaseBranch = "$($env:releaseBranchPrefix)" + "${{ needs.CreateRelease.outputs.releaseVersion }}"
+          Write-Host "Creating release branch $releaseBranch"
+          git checkout -b $releaseBranch
           git config user.name ${{ github.actor}}
           git config user.email ${{ github.actor}}@users.noreply.github.com
-          git commit --allow-empty -m "Release branch ${{ needs.CreateRelease.outputs.releaseBranch }}"
-          git push origin ${{ needs.CreateRelease.outputs.releaseBranch }}
+          git commit --allow-empty -m "Release branch $releaseBranch"
+          git push origin $releaseBranch
 
   UpdateVersionNumber:
+    needs: [ CreateRelease, UploadArtifacts ]
     if: ${{ github.event.inputs.updateVersionNumber!='' }}
     runs-on: [ windows-latest ]
-    needs: [ CreateRelease, UploadArtifacts ]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -323,7 +352,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Update Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v4.0
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v5.1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -332,16 +361,16 @@ jobs:
           directCommit: ${{ github.event.inputs.directCommit }}
 
   PostProcess:
+    needs: [ CreateRelease, UploadArtifacts, CreateReleaseBranch, UpdateVersionNumber ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ CreateRelease, UploadArtifacts, CreateReleaseBranch, UpdateVersionNumber ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0094"

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -21,16 +21,17 @@ on:
         required: true
         default: '50000..99999'
       sampleCode:
-        description: Include Sample code (Y/N)
-        required: false
-        default: 'Y'
-      directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Include Sample code?
         type: boolean
+        default: true
+      directCommit:
+        description: Direct Commit?
+        type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -46,26 +47,32 @@ env:
 
 jobs:
   CreateTestApp:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0095"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -73,7 +80,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Creating a new test app
-        uses: microsoft/AL-Go-Actions/CreateApp@v4.0
+        uses: microsoft/AL-Go-Actions/CreateApp@v5.1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -88,7 +95,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0095"

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 defaults:
   run:
@@ -17,6 +18,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -27,21 +29,26 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0101"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
@@ -52,7 +59,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -80,16 +87,16 @@ jobs:
       artifactsNameSuffix: 'Current'
 
   PostProcess:
+    needs: [ Initialization, Build ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Build ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0101"

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -1,0 +1,71 @@
+name: ' Deploy Reference Documentation'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  pages: write
+  id-token: write
+
+defaults:
+  run:
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+
+jobs:
+  DeployALDoc:
+    runs-on: [ windows-latest ]
+    name: Deploy Reference Documentation
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize the workflow
+        id: init
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
+        with:
+          shell: powershell
+          eventId: "DO0097"
+        
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
+        with:
+          shell: powershell
+
+      - name: Determine Deployment Environments
+        id: DetermineDeploymentEnvironments
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v5.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          shell: powershell
+          getEnvironments: 'github-pages'
+          type: 'Publish'
+            
+      - name: Setup Pages
+        if: steps.DetermineDeploymentEnvironments.outputs.deployALDocArtifact == 1
+        uses: actions/configure-pages@v5
+        
+      - name: Build Reference Documentation
+        uses: microsoft/AL-Go-Actions/BuildReferenceDocumentation@v5.1
+        with:
+          shell: powershell
+          artifacts: 'latest'
+        
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ".aldoc/_site/"
+        
+      - name: Deploy to GitHub Pages
+        if: steps.DetermineDeploymentEnvironments.outputs.deployALDocArtifact == 1
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -5,20 +5,21 @@ run-name: "Increment Version Number in [${{ github.ref_name }}]"
 on:
   workflow_dispatch:
     inputs:
-      project:
-        description: Project name if the repository is setup for multiple projects (* for all projects)
+      projects:
+        description: Comma-separated list of project name patterns if the repository is setup for multiple projects (default is * for all projects)
         required: false
         default: '*'
       versionNumber:
         description: Updated Version Number. Use Major.Minor for absolute change, use +Major.Minor for incremental change.
         required: true
       directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
-      useGhTokenWorkflow:
-        description: Use GhTokenWorkflow for Pull Request/COMMIT
+        description: Direct Commit?
         type: boolean
+        default: false
+      useGhTokenWorkflow:
+        description: Use GhTokenWorkflow for PR/Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -34,26 +35,32 @@ env:
 
 jobs:
   IncrementVersionNumber:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0096"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -61,18 +68,18 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v4.0
+        uses: microsoft/AL-Go-Actions/IncrementVersionNumber@v5.1
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
           parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
-          project: ${{ github.event.inputs.project }}
+          projects: ${{ github.event.inputs.projects }}
           versionNumber: ${{ github.event.inputs.versionNumber }}
           directCommit: ${{ github.event.inputs.directCommit }}
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0096"

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 defaults:
   run:
@@ -17,6 +18,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -27,21 +29,26 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0099"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
@@ -52,7 +59,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -80,16 +87,16 @@ jobs:
       artifactsNameSuffix: 'NextMajor'
 
   PostProcess:
+    needs: [ Initialization, Build ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Build ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0099"

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 defaults:
   run:
@@ -17,6 +18,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -27,21 +29,26 @@ jobs:
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0100"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
@@ -52,7 +59,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -80,16 +87,16 @@ jobs:
       artifactsNameSuffix: 'NextMinor'
 
   PostProcess:
+    needs: [ Initialization, Build ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Build ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0100"

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   Initialization:
+    needs: [ ]
     runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
@@ -33,25 +34,30 @@ jobs:
       deploymentEnvironmentsJson: ${{ steps.DetermineDeploymentEnvironments.outputs.DeploymentEnvironmentsJson }}
       deviceCode: ${{ steps.Authenticate.outputs.deviceCode }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0097"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineDeploymentEnvironments@v5.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -69,7 +75,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         if: steps.DetermineDeploymentEnvironments.outputs.UnknownEnvironment == 1
         with:
           shell: powershell
@@ -101,7 +107,7 @@ jobs:
             Write-Host "No AuthContext provided for $envName, initiating Device Code flow"
             $ALGoHelperPath = "$([System.IO.Path]::GetTempFileName()).ps1"
             $webClient = New-Object System.Net.WebClient
-            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v4.0/AL-Go-Helper.ps1', $ALGoHelperPath)
+            $webClient.DownloadFile('https://raw.githubusercontent.com/microsoft/AL-Go-Actions/v5.1/AL-Go-Helper.ps1', $ALGoHelperPath)
             . $ALGoHelperPath
             DownloadAndImportBcContainerHelper
             $authContext = New-BcAuthContext -includeDeviceLogin -deviceLoginTimeout ([TimeSpan]::FromSeconds(0))
@@ -115,6 +121,9 @@ jobs:
     strategy: ${{ fromJson(needs.Initialization.outputs.environmentsMatrixJson) }}
     runs-on: ${{ fromJson(matrix.os) }}
     name: Deploy to ${{ matrix.environment }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.Deploy.outputs.environmentUrl }}
@@ -122,7 +131,7 @@ jobs:
       deviceCode: ${{ needs.Initialization.outputs.deviceCode }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: EnvName
         id: envName
@@ -132,41 +141,41 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_OUTPUT -Value "envName=$envName"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ steps.envName.outputs.envName }}-AuthContext,${{ steps.envName.outputs.envName }}_AuthContext,AuthContext,${{ steps.envName.outputs.envName }}-EnvironmentName,${{ steps.envName.outputs.envName }}_EnvironmentName,EnvironmentName,projects'
 
       - name: Deploy
         id: Deploy
-        uses: microsoft/AL-Go-Actions/Deploy@v4.0
+        uses: microsoft/AL-Go-Actions/Deploy@v5.1
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
-          shell: powershell
+          shell: ${{ matrix.shell }}
           environmentName: ${{ matrix.environment }}
           artifacts: ${{ github.event.inputs.appVersion }}
           type: 'Publish'
           deploymentEnvironmentsJson: ${{ needs.Initialization.outputs.deploymentEnvironmentsJson }}
 
   PostProcess:
+    needs: [ Initialization, Deploy ]
     if: always()
     runs-on: [ windows-latest ]
-    needs: [ Initialization, Deploy ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0097"

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -25,9 +25,9 @@ env:
 jobs:
   PregateCheck:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
-    runs-on: [ windows-latest ]
+    runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v4.0
+      - uses: microsoft/AL-Go-Actions/VerifyPRChanges@v5.1
 
   Initialization:
     needs: [ PregateCheck ]
@@ -40,24 +40,30 @@ jobs:
       projects: ${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}
       projectDependenciesJson: ${{ steps.determineProjectsToBuild.outputs.ProjectDependenciesJson }}
       buildOrderJson: ${{ steps.determineProjectsToBuild.outputs.BuildOrderJson }}
+      baselineWorkflowRunId: ${{ steps.determineProjectsToBuild.outputs.BaselineWorkflowRunId }}
       workflowDepth: ${{ steps.DetermineWorkflowDepth.outputs.WorkflowDepth }}
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
           ref: refs/pull/${{ github.event.number }}/merge
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0104"
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
 
@@ -68,7 +74,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v4.0
+        uses: microsoft/AL-Go-Actions/DetermineProjectsToBuild@v5.1
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -92,18 +98,20 @@ jobs:
       projectName: ${{ matrix.projectName }}
       buildMode: ${{ matrix.buildMode }}
       projectDependenciesJson: ${{ needs.Initialization.outputs.projectDependenciesJson }}
+      baselineWorkflowRunId: ${{ needs.Initialization.outputs.baselineWorkflowRunId }}
       secrets: 'licenseFileUrl,keyVaultCertificateUrl,*keyVaultCertificatePassword,keyVaultClientId,gitHubPackagesContext,applicationInsightsConnectionString'
       publishThisBuildArtifacts: ${{ needs.Initialization.outputs.workflowDepth > 1 }}
+      artifactsNameSuffix: 'PR${{ github.event.number }}'
 
   StatusCheck:
-    runs-on: [ windows-latest ]
     needs: [ Initialization, Build ]
     if: (!cancelled())
+    runs-on: [ windows-latest ]
     name: Pull Request Status Check
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v4.0
+        uses: microsoft/AL-Go-Actions/PullRequestStatusCheck@v5.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -1,0 +1,37 @@
+name: 'Troubleshooting'
+
+on:
+  workflow_dispatch:
+    inputs:
+      displayNameOfSecrets:
+        description: Display the name (not the value) of secrets available to the repository
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: read
+
+defaults:
+  run:
+    shell: powershell
+
+env:
+  ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
+  ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
+
+jobs:
+  Troubleshooting:
+    runs-on: [ windows-latest ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Troubleshooting
+        uses: microsoft/AL-Go-Actions/Troubleshooting@v5.1
+        with:
+          shell: powershell
+          gitHubSecrets: ${{ toJson(secrets) }}
+          displayNameOfSecrets: ${{ github.event.inputs.displayNameOfSecrets }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -7,10 +7,14 @@ on:
         description: Template Repository URL (current is https://github.com/microsoft/AL-Go-PTE@main)
         required: false
         default: ''
+      downloadLatest:
+        description: Download latest from template repository
+        type: boolean
+        default: true
       directCommit:
-        description: Direct COMMIT (Y/N)
-        required: false
-        default: 'N'
+        description: Direct Commit?
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -25,27 +29,33 @@ env:
 
 jobs:
   UpdateALGoSystemFiles:
+    needs: [ ]
     runs-on: [ windows-latest ]
     steps:
+      - name: Dump Workflow Information
+        uses: microsoft/AL-Go-Actions/DumpWorkflowInfo@v5.1
+        with:
+          shell: powershell
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowInitialize@v5.1
         with:
           shell: powershell
           eventId: "DO0098"
 
       - name: Read settings
-        uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -62,33 +72,37 @@ jobs:
             Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "templateUrl=$templateUrl"
           }
 
-      - name: Calculate DirectCommit
+      - name: Calculate Input
         env:
-          directCommit: ${{ github.event.inputs.directCommit }}
+          directCommit: '${{ github.event.inputs.directCommit }}'
+          downloadLatest: ${{ github.event.inputs.downloadLatest }}
           eventName: ${{ github.event_name }}
         run: |
           $errorActionPreference = "Stop"; $ProgressPreference = "SilentlyContinue"; Set-StrictMode -Version 2.0
           $directCommit = $ENV:directCommit
+          $downloadLatest = $ENV:downloadLatest
           Write-Host $ENV:eventName
           if ($ENV:eventName -eq 'schedule') {
-            Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit = Y"
-            $directCommit = 'Y'
+            Write-Host "Running Update AL-Go System Files on a schedule. Setting DirectCommit and DownloadLatest to true"
+            $directCommit = 'true'
+            $downloadLatest = 'true'
           }
-          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "DirectCommit=$directCommit"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "directCommit=$directCommit"
+          Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go-Actions/CheckForUpdates@v4.0
+        uses: microsoft/AL-Go-Actions/CheckForUpdates@v5.1
         with:
           shell: powershell
-          parentTelemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
           token: ${{ fromJson(steps.ReadSecrets.outputs.Secrets).ghTokenWorkflow }}
-          Update: Y
+          downloadLatest: ${{ env.downloadLatest }}
+          update: 'Y'
           templateUrl: ${{ env.templateUrl }}
           directCommit: ${{ env.directCommit }}
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v4.0
+        uses: microsoft/AL-Go-Actions/WorkflowPostProcess@v5.1
         with:
           shell: powershell
           eventId: "DO0098"

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -36,6 +36,11 @@ on:
         description: Build mode used when building the artifacts
         required: true
         type: string
+      baselineWorkflowRunId:
+        description: ID of the baseline workflow run, from where to download the current project dependencies, in case they are not built in the current workflow run
+        required: false
+        default: '0'
+        type: string
       secrets:
         description: A comma-separated string with the names of the secrets, required for the workflow.
         required: false
@@ -43,14 +48,12 @@ on:
         type: string
       publishThisBuildArtifacts:
         description: Flag indicating whether this build artifacts should be published
-        required: false
-        default: false
         type: boolean
+        default: false
       publishArtifacts:
         description: Flag indicating whether the artifacts should be published
-        required: false
-        default: false
         type: boolean
+        default: false
       artifactsNameSuffix:
         description: Suffix to add to the artifacts names
         required: false
@@ -58,18 +61,20 @@ on:
         type: string
       signArtifacts:
         description: Flag indicating whether the apps should be signed
-        required: false
-        default: false
         type: boolean
+        default: false
       useArtifactCache:
         description: Flag determining whether to use the Artifacts Cache
-        required: false
-        default: false
         type: boolean
+        default: false
       parentTelemetryScopeJson:
         description: Specifies the telemetry scope for the telemetry signal
         required: false
         type: string
+
+permissions:
+  contents: read
+  actions: read
 
 env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
@@ -77,179 +82,192 @@ env:
 
 jobs:
   BuildALGoProject:
+    needs: [ ]
     runs-on: ${{ fromJson(inputs.runsOn) }}
+    defaults:
+      run:
+        shell: ${{ inputs.shell }}
     name: ${{ inputs.projectName }} (${{ inputs.buildMode }})
     steps:
-        - name: Checkout
-          uses: actions/checkout@v3
-          with:
-            ref: ${{ inputs.checkoutRef }}
-            lfs: true
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkoutRef }}
+          lfs: true
 
-        - name: Read settings
-          uses: microsoft/AL-Go-Actions/ReadSettings@v4.0
-          with:
-            shell: ${{ inputs.shell }}
-            project: ${{ inputs.project }}
-            get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact
+      - name: Read settings
+        uses: microsoft/AL-Go-Actions/ReadSettings@v5.1
+        with:
+          shell: ${{ inputs.shell }}
+          project: ${{ inputs.project }}
+          get: useCompilerFolder,keyVaultCodesignCertificateName,doNotSignApps,doNotRunTests,artifact,generateDependencyArtifact
 
-        - name: Read secrets
-          id: ReadSecrets
-          if: github.event_name != 'pull_request'
-          uses: microsoft/AL-Go-Actions/ReadSecrets@v4.0
-          with:
-            shell: ${{ inputs.shell }}
-            gitHubSecrets: ${{ toJson(secrets) }}
-            getSecrets: '${{ inputs.secrets }},appDependencyProbingPathsSecrets'
+      - name: Read secrets
+        id: ReadSecrets
+        if: github.event_name != 'pull_request'
+        uses: microsoft/AL-Go-Actions/ReadSecrets@v5.1
+        with:
+          shell: ${{ inputs.shell }}
+          gitHubSecrets: ${{ toJson(secrets) }}
+          getSecrets: '${{ inputs.secrets }},appDependencyProbingPathsSecrets'
 
-        - name: Determine ArtifactUrl
-          uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v4.0
-          id: determineArtifactUrl
-          with:
-            shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            project: ${{ inputs.project }}
+      - name: Determine ArtifactUrl
+        uses: microsoft/AL-Go-Actions/DetermineArtifactUrl@v5.1
+        id: determineArtifactUrl
+        with:
+          shell: ${{ inputs.shell }}
+          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+          project: ${{ inputs.project }}
 
-        - name: Cache Business Central Artifacts
-          if: env.useCompilerFolder == 'True' && inputs.useArtifactCache && env.artifactCacheKey
-          uses: actions/cache@v3
-          with:
-            path: .artifactcache
-            key: ${{ env.artifactCacheKey }}
+      - name: Cache Business Central Artifacts
+        if: env.useCompilerFolder == 'True' && inputs.useArtifactCache && env.artifactCacheKey
+        uses: actions/cache@v4
+        with:
+          path: .artifactcache
+          key: ${{ env.artifactCacheKey }}
 
-        - name: Download Project Dependencies
-          id: DownloadProjectDependencies
-          uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v4.0
-          env:
-            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
-          with:
-            shell: ${{ inputs.shell }}
-            project: ${{ inputs.project }}
-            buildMode: ${{ inputs.buildMode }}
-            projectsDependenciesJson: ${{ inputs.projectDependenciesJson }}
+      - name: Download Project Dependencies
+        id: DownloadProjectDependencies
+        uses: microsoft/AL-Go-Actions/DownloadProjectDependencies@v5.1
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
+        with:
+          shell: ${{ inputs.shell }}
+          project: ${{ inputs.project }}
+          buildMode: ${{ inputs.buildMode }}
+          projectsDependenciesJson: ${{ inputs.projectDependenciesJson }}
+          baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
-        - name: Run pipeline
-          id: RunPipeline
-          uses: microsoft/AL-Go-Actions/RunPipeline@v4.0
-          env:
-            Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
-            BuildMode: ${{ inputs.buildMode }}
-          with:
-            shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            artifact: ${{ env.artifact }}
-            project: ${{ inputs.project }}
-            buildMode: ${{ inputs.buildMode }}
-            installAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedApps }}
-            installTestAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedTestApps }}
+      - name: Build
+        uses: microsoft/AL-Go-Actions/RunPipeline@v5.1
+        env:
+          Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
+          BuildMode: ${{ inputs.buildMode }}
+        with:
+          shell: ${{ inputs.shell }}
+          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+          artifact: ${{ env.artifact }}
+          project: ${{ inputs.project }}
+          buildMode: ${{ inputs.buildMode }}
+          installAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedApps }}
+          installTestAppsJson: ${{ steps.DownloadProjectDependencies.outputs.DownloadedTestApps }}
 
-        - name: Sign
-          if: inputs.signArtifacts && env.doNotSignApps == 'False' && env.keyVaultCodesignCertificateName != ''
-          id: sign
-          uses: microsoft/AL-Go-Actions/Sign@v4.0
-          with:
-            shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
-            azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
-            pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
-            parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
+      - name: Sign
+        if: inputs.signArtifacts && env.doNotSignApps == 'False' && env.keyVaultCodesignCertificateName != ''
+        id: sign
+        uses: microsoft/AL-Go-Actions/Sign@v5.1
+        with:
+          shell: ${{ needs.Initialization.outputs.githubRunnerShell }}
+          azureCredentialsJson: ${{ secrets.AZURE_CREDENTIALS }}
+          pathToFiles: '${{ inputs.project }}/.buildartifacts/Apps/*.app'
+          parentTelemetryScopeJson: ${{ needs.Initialization.outputs.telemetryScopeJson }}
 
-        - name: Calculate Artifact names
-          id: calculateArtifactsNames
-          uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v4.0
-          if: success() || failure()
-          with:
-            shell: ${{ inputs.shell }}
-            project: ${{ inputs.project }}
-            buildMode: ${{ inputs.buildMode }}
-            suffix: ${{ inputs.artifactsNameSuffix }}
+      - name: Calculate Artifact names
+        id: calculateArtifactsNames
+        uses: microsoft/AL-Go-Actions/CalculateArtifactNames@v5.1
+        if: success() || failure()
+        with:
+          shell: ${{ inputs.shell }}
+          project: ${{ inputs.project }}
+          buildMode: ${{ inputs.buildMode }}
+          suffix: ${{ inputs.artifactsNameSuffix }}
 
-        - name: Upload thisbuild artifacts - apps
-          if: inputs.publishThisBuildArtifacts
-          uses: actions/upload-artifact@v3
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/Apps/'
-            if-no-files-found: ignore
-            retention-days: 1
+      - name: Upload thisbuild artifacts - apps
+        if: inputs.publishThisBuildArtifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildAppsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/Apps/'
+          if-no-files-found: ignore
+          retention-days: 1
 
-        - name: Upload thisbuild artifacts - test apps
-          if: inputs.publishThisBuildArtifacts
-          uses: actions/upload-artifact@v3
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/TestApps/'
-            if-no-files-found: ignore
-            retention-days: 1
+      - name: Upload thisbuild artifacts - dependencies
+        if: inputs.publishThisBuildArtifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildDependenciesArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
+          if-no-files-found: ignore
+          retention-days: 1
 
-        - name: Publish artifacts - apps
-          uses: actions/upload-artifact@v3
-          if: inputs.publishArtifacts
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/Apps/'
-            if-no-files-found: ignore
+      - name: Upload thisbuild artifacts - test apps
+        if: inputs.publishThisBuildArtifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ThisBuildTestAppsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/TestApps/'
+          if-no-files-found: ignore
+          retention-days: 1
 
-        - name: Publish artifacts - dependencies
-          uses: actions/upload-artifact@v3
-          if: inputs.publishArtifacts
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
-            if-no-files-found: ignore
+      - name: Publish artifacts - apps
+        uses: actions/upload-artifact@v4
+        if: inputs.publishArtifacts
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.AppsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/Apps/'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - test apps
-          uses: actions/upload-artifact@v3
-          if: inputs.publishArtifacts
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.TestAppsArtifactsName }}
-            path: '${{ inputs.project }}/.buildartifacts/TestApps/'
-            if-no-files-found: ignore
+      - name: Publish artifacts - dependencies
+        uses: actions/upload-artifact@v4
+        if: inputs.publishArtifacts && env.generateDependencyArtifact == 'True'
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.DependenciesArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/Dependencies/'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - build output
-          uses: actions/upload-artifact@v3
-          if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',inputs.project)) != '')
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.BuildOutputArtifactsName }}
-            path: '${{ inputs.project }}/BuildOutput.txt'
-            if-no-files-found: ignore
+      - name: Publish artifacts - test apps
+        uses: actions/upload-artifact@v4
+        if: inputs.publishArtifacts
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.TestAppsArtifactsName }}
+          path: '${{ inputs.project }}/.buildartifacts/TestApps/'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - container event log
-          uses: actions/upload-artifact@v3
-          if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',inputs.project)) != '')
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.ContainerEventLogArtifactsName }}
-            path: '${{ inputs.project }}/ContainerEventLog.evtx'
-            if-no-files-found: ignore
+      - name: Publish artifacts - build output
+        uses: actions/upload-artifact@v4
+        if: (success() || failure()) && (hashFiles(format('{0}/BuildOutput.txt',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.BuildOutputArtifactsName }}
+          path: '${{ inputs.project }}/BuildOutput.txt'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - test results
-          uses: actions/upload-artifact@v3
-          if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',inputs.project)) != '')
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.TestResultsArtifactsName }}
-            path: '${{ inputs.project }}/TestResults.xml'
-            if-no-files-found: ignore
+      - name: Publish artifacts - container event log
+        uses: actions/upload-artifact@v4
+        if: (failure()) && (hashFiles(format('{0}/ContainerEventLog.evtx',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.ContainerEventLogArtifactsName }}
+          path: '${{ inputs.project }}/ContainerEventLog.evtx'
+          if-no-files-found: ignore
 
-        - name: Publish artifacts - bcpt test results
-          uses: actions/upload-artifact@v3
-          if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',inputs.project)) != '')
-          with:
-            name: ${{ steps.calculateArtifactsNames.outputs.BcptTestResultsArtifactsName }}
-            path: '${{ inputs.project }}/bcptTestResults.json'
-            if-no-files-found: ignore
+      - name: Publish artifacts - test results
+        uses: actions/upload-artifact@v4
+        if: (success() || failure()) && (hashFiles(format('{0}/TestResults.xml',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.TestResultsArtifactsName }}
+          path: '${{ inputs.project }}/TestResults.xml'
+          if-no-files-found: ignore
 
-        - name: Analyze Test Results
-          id: analyzeTestResults
-          if: (success() || failure()) && env.doNotRunTests == 'False'
-          uses: microsoft/AL-Go-Actions/AnalyzeTests@v4.0
-          with:
-            shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            project: ${{ inputs.project }}
+      - name: Publish artifacts - bcpt test results
+        uses: actions/upload-artifact@v4
+        if: (success() || failure()) && (hashFiles(format('{0}/bcptTestResults.json',inputs.project)) != '')
+        with:
+          name: ${{ steps.calculateArtifactsNames.outputs.BcptTestResultsArtifactsName }}
+          path: '${{ inputs.project }}/bcptTestResults.json'
+          if-no-files-found: ignore
 
-        - name: Cleanup
-          if: always()
-          uses: microsoft/AL-Go-Actions/PipelineCleanup@v4.0
-          with:
-            shell: ${{ inputs.shell }}
-            parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
-            project: ${{ inputs.project }}
+      - name: Analyze Test Results
+        id: analyzeTestResults
+        if: (success() || failure()) && env.doNotRunTests == 'False'
+        uses: microsoft/AL-Go-Actions/AnalyzeTests@v5.1
+        with:
+          shell: ${{ inputs.shell }}
+          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+          project: ${{ inputs.project }}
+
+      - name: Cleanup
+        if: always()
+        uses: microsoft/AL-Go-Actions/PipelineCleanup@v5.1
+        with:
+          shell: ${{ inputs.shell }}
+          parentTelemetryScopeJson: ${{ inputs.parentTelemetryScopeJson }}
+          project: ${{ inputs.project }}


### PR DESCRIPTION
## v5.1

### Issues

- Issue 1019 CI/CD Workflow still being scheduled after it was disabled
- Issue 1021 Error during Create Online Development Environment action
- Issue 1022 Error querying artifacts: No such host is known. (bcartifacts-exdbf9fwegejdqak.blob.core.windows.net:443)
- Issue 922 Deploy Reference Documentation (ALDoc) failed with custom
- ContainerName used during build was invalid if project names contained special characters
- Issue 1009 by adding a includeDependencies property in DeliverToAppSource
- Issue 997 'Deliver to AppSource' action fails for projects containing a space
- Issue 987 Resource not accessible by integration when creating release from specific version
- Issue 979 Publish to AppSource Documentation
- Issue 1018 Artifact setting - possibility to read version from app.json
- Issue 1008 Allow PullRequestHandler to use ubuntu or self hosted runners for all jobs except for pregateCheck
- Issue 962 Finer control of "shell"-property
- Issue 1041 Harden the version comparison when incrementing version number
- Issue 1042 Downloading artifacts from GitHub doesn't work with branch names which include forward slashes

### Better artifact selection

The artifact setting in your project settings file can now contain a `*` instead of the version number. This means that AL-Go for GitHub will determine the application dependency for your projects together with the `applicationDependency` setting and determine which Business Central version is needed for the project.
- `"artifact": "//*//latest"` will give you the latest Business Central version, higher than your application dependency and with the same major.minor as your application dependency.
- `"artifact": "//*//first"` will give you the first Business Central version, higher than your application dependency and with the same major.minor as your application dependency.

### New Settings

- `deliverToAppSource`: a JSON object containing the following properties
  - **productId** must be the product Id from partner Center.
  - **mainAppFolder** specifies the appFolder of the main app if you have multiple apps in the same project.
  - **continuousDelivery** can be set to true to enable continuous delivery of every successful build to AppSource Validation. Note that the app will only be in preview in AppSource and you will need to manually press GO LIVE in order for the app to be promoted to production.
  - **includeDependencies** can be set to an array of file names (incl. wildcards) which are the names of the dependencies to include in the AppSource submission. Note that you need to set `generateDependencyArtifact` in the project settings file to true in order to include dependencies.
- Add `shell` as a property under `DeployTo` structure

### Deprecated Settings

- `appSourceContinuousDelivery` is moved to the `deliverToAppSource` structure
- `appSourceMainAppFolder` is moved to the `deliverToAppSource` structure
- `appSourceProductId` is moved to the `deliverToAppSource` structure

### New parameter -clean on localdevenv and clouddevenv

Adding -clean when running localdevenv or clouddevenv will create a clean development environment without compiling and publishing your apps.

## v5.0

### Issues
- Issue 940 Publish to Environment is broken when specifying projects to publish
- Issue 994 CI/CD ignores Deploy to GitHub Pages in private repositories

### New Settings
- `UpdateALGoSystemFilesEnvironment`: The name of the environment that is referenced in job `UpdateALGoSystemFiles` in the _Update AL-Go System Files_ workflow. See [jobs.<job_id>.environment](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) for more information. Currently, only setting the environment name is supported.

### Issues
- Support release branches that start with releases/
- Issue 870 Improve Error Handling when CLI is missing
- Issue 889 CreateRelease and IncrementVersionNumber workflow did not handle wild characters in `appFolders`, `testFolders` or `bcptTestFolders` settings.
- Issue 973 Prerelease is not used for deployment

### Build modes
AL-Go ships with Default, Translated and Clean mode out of the box. Now you can also define custom build modes in addition to the ones shipped with AL-Go. This allows you to define your own build modes, which can be used to build your apps in different ways. By default, a custom build mode will build the apps similarly to the Default mode but this behavior can be overridden in e.g. script overrides in your repository.

## v4.1

### New Settings
- `templateSha`: The SHA of the version of AL-Go currently used

### New Actions
- `DumpWorkflowInfo`: Dump information about running workflow
- `Troubleshooting` : Run troubleshooting for repository

### Update AL-Go System Files
Add another parameter when running Update AL-Go System Files, called downloadLatest, used to indicate whether to download latest version from template repository. Default value is true.
If false, the templateSha repository setting is used to download specific AL-Go System Files when calculating new files.

### Issues
- Issue 782 Exclude '.altestrunner/' from template .gitignore
- Issue 823 Dependencies from prior build jobs are not included when using useProjectDependencies
- App artifacts for version 'latest' are now fetched from the latest CICD run that completed and successfully built all the projects for the corresponding branch.
- Issue 824 Utilize `useCompilerFolder` setting when creating an development environment for an AL-Go project.
- Issue 828 and 825 display warnings for secrets, which might cause AL-Go for GitHub to malfunction

### New Settings

- `alDoc` : JSON object with properties for the ALDoc reference document generation
  - **continuousDeployment** = Determines if reference documentation will be deployed continuously as part of CI/CD. You can run the **Deploy Reference Documentation** workflow to deploy manually or on a schedule. (Default false)
  - **deployToGitHubPages** = Determines whether or not the reference documentation site should be deployed to GitHub Pages for the repository. In order to deploy to GitHub Pages, GitHub Pages must be enabled and set to GitHub Actions. (Default true)
  - **maxReleases** = Maximum number of releases to include in the reference documentation. (Default 3)
  - **groupByProject** = Determines whether projects in multi-project repositories are used as folders in reference documentation
  - **includeProjects** = An array of projects to include in the reference documentation. (Default all)
  - **excludeProjects** = An array of projects to exclude in the reference documentation. (Default none)-
  - **header** = Header for the documentation site. (Default: Documentation for...)
  - **footer** = Footer for the documentation site. (Default: Made with...)
  - **defaultIndexMD** = Markdown for the landing page of the documentation site. (Default: Reference documentation...)
  - **defaultReleaseMD** = Markdown for the landing page of the release sites. (Default: Release reference documentation...)
  - *Note that in header, footer, defaultIndexMD and defaultReleaseMD you can use the following placeholders: {REPOSITORY}, {VERSION}, {INDEXTEMPLATERELATIVEPATH}, {RELEASENOTES}*

### New Workflows
- **Deploy Reference Documentation** is a workflow, which you can invoke manually or on a schedule to generate and deploy reference documentation using the aldoc tool, using the ALDoc setting properties described above.
- **Troubleshooting** is a workflow, which you can invoke manually to run troubleshooting on the repository and check for settings or secrets, containing illegal values. When creating issues on https://github.com/microsoft/AL-Go/issues, we might ask you to run the troubleshooter to help identify common problems.

### Support for ALDoc reference documentation tool
ALDoc reference documentation tool is now supported for generating and deploying reference documentation for your projects either continuously or manually/scheduled.

